### PR TITLE
Fix typo in .sort

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -87,7 +87,7 @@ class Body {
     return this.world.queryRect(x, y, w, h)
       .map((other) => this._collide(other, goalX, goalY, filter))
       .filter((collision) => !!collision)
-      .sort((a, b) => a.distance < b.distance)
+      .sort((a, b) => a.distance - b.distance)
   }
 
   _collide (other, goalX, goalY, filter = (o) => defaultResp) {


### PR DESCRIPTION
The sort compare function accepts a number, not a boolean. This solves a "sticky corners" issue I was encountering in my WIP platformer, and will probably fix other related issues as well